### PR TITLE
Improve formatting of README files

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,7 @@
-## rp2350-minimal-riscv
+# rp2350-minimal-riscv
 
 As in my rp2350-minimal repository, we refer to RP2350's datasheet as [rp2350]. It can be found at <https://datasheets.raspberrypi.com/rp2350/rp2350-datasheet.pdf>.
-The present repository is a twin to the rp2350-minimal repository. It contains the same programs, but adapted to run on the RISC-V cores. The only exception is the systick program. SysTick is an ARM
+
+The present repository is a twin to the [rp2350-minimal](https://github.com/mtkos/rp2350-minimal) repository. It contains the same programs, but adapted to run on the RISC-V cores. The only exception is the `systick` program. SysTick is an ARM
 peripheral, not present on RP2350's RISC-V cores. Instead, there is the RISC-V platform timer, see [rp2350], section 3.1.8, which can be used for similar purposes. The program is still called
-systick, although it is very different from the ARM version.
+`systick`, although it is very different from the ARM version.

--- a/Readme.md
+++ b/Readme.md
@@ -8,7 +8,7 @@ peripheral, not present on RP2350's RISC-V cores. Instead, there is the RISC-V p
 
 ## Prerequisites
 
-Compiler `gcc-riscv64-unknown-elf` is needed.
+Compiler `riscv64-unknown-elf-gcc` is needed.
 
 * Debian/Ubuntu: install package `gcc-riscv64-unknown-elf`.
 

--- a/Readme.md
+++ b/Readme.md
@@ -12,6 +12,13 @@ Compiler `gcc-riscv64-unknown-elf` is needed.
 
 * Debian/Ubuntu: install package `gcc-riscv64-unknown-elf`.
 
+### Minimum GCC version
+
+Probably the minimum GCC version to build a code for RP2350 is 12.2, see [raspberrypi/pico-bootrom-rp2350#Getting a RISC-V compiler](https://github.com/raspberrypi/pico-bootrom-rp2350/blob/master/README.md#getting-a-risc-v-compiler):
+> Not all the fancy instructions supported by Hazard3 will be in the compilers in people's package managers right now (and we do want to use them here since the bitmanip instructions improve code density). At time of writing the master branch of `riscv-gnu-toolchain` is GCC 12, which does support the bit manipulation instructions.
+>
+> The following compiler is known to be correct: `corev-openhw-gcc-ubuntu2204-20240114`. Others may or may not; because space is very tight, slight compiler variations can cause code not to fit.
+
 ## How to use
 
 Navigate into a needed folder (for example, with `cd …` command), then run `make all` to build binaries.

--- a/Readme.md
+++ b/Readme.md
@@ -5,3 +5,17 @@ As in my rp2350-minimal repository, we refer to RP2350's datasheet as [rp2350]. 
 The present repository is a twin to the [rp2350-minimal](https://github.com/mtkos/rp2350-minimal) repository. It contains the same programs, but adapted to run on the RISC-V cores. The only exception is the `systick` program. SysTick is an ARM
 peripheral, not present on RP2350's RISC-V cores. Instead, there is the RISC-V platform timer, see [rp2350], section 3.1.8, which can be used for similar purposes. The program is still called
 `systick`, although it is very different from the ARM version.
+
+## Prerequisites
+
+Compiler `gcc-riscv64-unknown-elf` is needed.
+
+* Debian/Ubuntu: install package `gcc-riscv64-unknown-elf`.
+
+## How to use
+
+Navigate into a needed folder (for example, with `cd …` command), then run `make all` to build binaries.
+
+Flashing: copy `*.uf2` file into the Raspberry PI pico2 volume.
+
+[rp2350]: https://datasheets.raspberrypi.com/rp2350/rp2350-datasheet.pdf

--- a/blink-multicore/Readme.md
+++ b/blink-multicore/Readme.md
@@ -1,4 +1,4 @@
 # the blink-multicore program
 
-The only difference with the ARM version is that RISC-V has no "sev" instruction. Instead, the Hazard3 has a custom instruction, described in [rp2350], section 3.8.6.3.2, and encoded as 
-"slt x0, x0, x1", so that it will be accepted by the assembler. It can be used as a replacement for "sev".
+The only difference with the ARM version is that RISC-V has no `sev` instruction. Instead, the Hazard3 has a custom instruction, described in [rp2350], section 3.8.6.3.2, and encoded as
+`slt x0, x0, x1`, so that it will be accepted by the assembler. It can be used as a replacement for `sev`.

--- a/blink-small/Readme.md
+++ b/blink-small/Readme.md
@@ -1,5 +1,6 @@
 # the blink-small program
 
 The main program is identical to the ARM version. The startup code is different. For RISC-V, the bootrom hands over program flow to the first instruction in flash, see [rp2350], section 5.9.5.2.
+
 So the startup code sets the stack pointer and jumps to the main program. The magic bytes ([rp2350], section 5.9.5.2) have been put right after the jump instruction. To assure that they are
-word-aligned, the assembly option norvc (no compressed instructions) is used.
+word-aligned, the assembly option `norvc` (no compressed instructions) is used.

--- a/exti-interrupt/Readme.md
+++ b/exti-interrupt/Readme.md
@@ -1,5 +1,5 @@
 # the exti-interrupt program
 
-The program is entirely similar to the ARM version, with the exception of interrupt configuration. This is done as in the systick program. Only instead of the MTIE bit the MEIE (enable external
-interrupts) bit has to be set in the mie register. Finally, a bit, corresponding to the interrupt number, has to be set in the external interrupt enable array. This is done through the
-meiea control register.
+The program is entirely similar to the ARM version, with the exception of interrupt configuration. This is done as in the `systick` program. Only instead of the `MTIE` bit, the `MEIE` (enable external
+interrupts) bit has to be set in the `mie` register. Finally, a bit, corresponding to the interrupt number, has to be set in the external interrupt enable array. This is done through the
+`meiea` control register.

--- a/picolibc-example/Readme.md
+++ b/picolibc-example/Readme.md
@@ -1,5 +1,5 @@
 # the picolib-example program
 
 Using picolibc requires a little tweaking. To get the second stage bootloader at the first 256 of flash, we convert the raw bytes
-of the binary to an assembler 'program', boot.s, padding it with zeroes to a size of 256 bytes, with .section attribute .text.init.enter. The picolibc linker script places this section
+of the binary to an assembler 'program', `boot.s`, padding it with zeroes to a size of 256 bytes, with `.section` attribute `.text.init.enter`. The picolibc linker script places this section
 at the beginning of flash.


### PR DESCRIPTION
Slightly improved Markdown formatting:

* added newlines to split paragraphs
* added inline codeblocks for filenames, register names, commands, …

Also, Markdown code like `[rp2350]` renders wrong, probably we need to follow guide like https://commonmark.org/help/tutorial/07-links.html or https://stackoverflow.com/questions/41345160/.